### PR TITLE
Add `locally` and `ilocally` functions.

### DIFF
--- a/src/Control/Effect/Optics.hs
+++ b/src/Control/Effect/Optics.hs
@@ -7,12 +7,15 @@ module Control.Effect.Optics
   ( -- * Reader operations
     eview,
     eviews,
+    locally,
+
     -- * State operations
     use,
     uses,
     preuse,
     assign,
     modifying,
+
     -- * Infix operators
     (.=),
     (?=),
@@ -27,7 +30,6 @@ import Optics.Core
 -- | View the target of a 'Lens', 'Iso', or 'Getter' in the current context.
 --
 -- This function is prefixed so as not to collide with 'Optics.Core.view'.
---
 eview ::
   forall r a m sig k is.
   ( Is k A_Getter,
@@ -49,6 +51,18 @@ eviews ::
   m b
 eviews l f = Reader.asks (f . view l)
 {-# INLINE eviews #-}
+
+-- | Given a monadic argument, evaluate it in a context modified by applying
+-- the provided function to the target of the provided 'Setter', 'Lens', or 'Traversal'.
+locally ::
+  ( Is k A_Setter,
+    Has (Reader.Reader r) sig m
+  ) =>
+  Optic k is r r a b ->
+  (a -> b) ->
+  m c ->
+  m c
+locally l f = Reader.local (over l f)
 
 -- | Use the target of a 'Lens', 'Iso', or 'Getter' in the current state.
 use ::

--- a/src/Control/Effect/Optics/Indexed.hs
+++ b/src/Control/Effect/Optics/Indexed.hs
@@ -5,6 +5,7 @@ module Control.Effect.Optics.Indexed
   ( -- * Indexed reader operations
     iview,
     iviews,
+    ilocally,
 
     -- * Indexed state operations
     iuse,
@@ -24,6 +25,11 @@ iview l = Reader.asks (Optics.iview l)
 -- | View the index and value of an indexed getter into the current environment and pass them to the provided function.
 iviews :: (Is k A_Getter, is `HasSingleIndex` i, Has (Reader.Reader r) sig m) => Optic' k is r a -> (i -> a -> m b) -> m b
 iviews l f = Reader.ask >>= Optics.iviews l f
+
+-- | Given a monadic argument, evaluate it in a context modified by applying
+-- the provided function to the index and target of the provided indexed 'Setter', 'Lens', or 'Traversal'.
+ilocally :: (Has (Reader s) sig m, is `HasSingleIndex` i, Is k A_Setter) => Optic k is s s a1 b -> (i -> a1 -> b) -> m a2 -> m a2
+ilocally l f = Reader.local (iover l f)
 
 -- | Extract the index and target of an indexed getter in the current state as a pair.
 iuse :: (Is k A_Getter, is `HasSingleIndex` i, Has (State s) sig m) => Optic' k is s a -> m (i, a)


### PR DESCRIPTION
@robrix indicated that these are useful, so the more, the merrier, imo.