### PR TITLE
Specifies the order of the type var of the function 'modifying'

### DIFF
--- a/src/Control/Effect/Optics.hs
+++ b/src/Control/Effect/Optics.hs
@@ -119,6 +119,7 @@ assign l x = State.modify (set' l x)
 -- | Map over the target(s) of an 'Optic' in our monadic state.
 -- The action and the optic operation are applied strictly.
 modifying ::
+  forall s a b m sig k is.
   ( Is k A_Setter,
     Has (State.State s) sig m
   ) =>


### PR DESCRIPTION
```haskell
--  The default type var order is inconvenient to use
modifying :: forall (k :: OpticKind) s (sig :: (Type -> Type) -> Type -> Type)
       (m :: Type -> Type) (is :: IxList) a b.(Is k A_Setter, Has (State s) sig m) => Optic k is s s a b -> (a -> b) -> m ()
-- example
modifying @_ @Player #damage (+ enemyAttack)
```

